### PR TITLE
Disable Some SuperLinter Checks

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -35,8 +35,29 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: .github/super-linter-configurations
           YAML_ERROR_ON_WARNING: true
-          VALIDATE_GIT_COMMITLINT: false
+          VALIDATE_CSS: false
           VALIDATE_EDITORCONFIG: false
+          VALIDATE_GIT_COMMITLINT: false
+          VALIDATE_GO: false
+          VALIDATE_GO_MODULES: false
+          VALIDATE_GO_RELEASER: false
+          VALIDATE_JAVASCRIPT_ES: false
+          VALIDATE_JAVASCRIPT_PRETTIER: false
+          VALIDATE_JAVASCRIPT_STANDARD: false
+          VALIDATE_JSON: false
+          VALIDATE_JSX: false
+          VALIDATE_JSX_PRETTIER: false
+          VALIDATE_PYTHON_BLACK: false
+          VALIDATE_PYTHON_FLAKE8: false
+          VALIDATE_PYTHON_ISORT: false
+          VALIDATE_PYTHON_MYPY: false
+          VALIDATE_PYTHON_PYLINT: false
+          VALIDATE_PYTHON_RUFF: false
+          VALIDATE_TSX: false
+          VALIDATE_TSX_PRETTIER: false
+          VALIDATE_TYPESCRIPT_ES: false
+          VALIDATE_TYPESCRIPT_PRETTIER: false
+          VALIDATE_TYPESCRIPT_STANDARD: false
 
   common-code-checks:
     name: Common Code Checks


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/workflows/code-checks.yml` file to adjust the validation rules for the super-linter configuration. The changes primarily involve disabling several validation checks for various programming languages and tools.

### Updates to super-linter configuration:

* Disabled validation for CSS (`VALIDATE_CSS`) and moved the `VALIDATE_GIT_COMMITLINT` setting to a new position.
* Added and disabled validation for multiple tools and languages, including Go (`VALIDATE_GO`, `VALIDATE_GO_MODULES`, `VALIDATE_GO_RELEASER`), JavaScript (`VALIDATE_JAVASCRIPT_ES`, `VALIDATE_JAVASCRIPT_PRETTIER`, `VALIDATE_JAVASCRIPT_STANDARD`), JSON (`VALIDATE_JSON`), JSX (`VALIDATE_JSX`, `VALIDATE_JSX_PRETTIER`), Python (`VALIDATE_PYTHON_BLACK`, `VALIDATE_PYTHON_FLAKE8`, `VALIDATE_PYTHON_ISORT`, `VALIDATE_PYTHON_MYPY`, `VALIDATE_PYTHON_PYLINT`, `VALIDATE_PYTHON_RUFF`), and TypeScript/TSX (`VALIDATE_TSX`, `VALIDATE_TSX_PRETTIER`, `VALIDATE_TYPESCRIPT_ES`, `VALIDATE_TYPESCRIPT_PRETTIER`, `VALIDATE_TYPESCRIPT_STANDARD`).