### PR TITLE
Remove Deprecated SuperLinter Variables

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -43,7 +43,6 @@ jobs:
           VALIDATE_GO_RELEASER: false
           VALIDATE_JAVASCRIPT_ES: false
           VALIDATE_JAVASCRIPT_PRETTIER: false
-          VALIDATE_JAVASCRIPT_STANDARD: false
           VALIDATE_JSON: false
           VALIDATE_JSX: false
           VALIDATE_JSX_PRETTIER: false
@@ -57,7 +56,6 @@ jobs:
           VALIDATE_TSX_PRETTIER: false
           VALIDATE_TYPESCRIPT_ES: false
           VALIDATE_TYPESCRIPT_PRETTIER: false
-          VALIDATE_TYPESCRIPT_STANDARD: false
 
   common-code-checks:
     name: Common Code Checks


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/workflows/code-checks.yml` file to remove unused validation flags for JavaScript and TypeScript code standards.

### Workflow configuration updates:

* Removed the `VALIDATE_JAVASCRIPT_STANDARD` flag from the workflow configuration, as it is no longer required. (`.github/workflows/code-checks.yml`, [.github/workflows/code-checks.ymlL46](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L46))
* Removed the `VALIDATE_TYPESCRIPT_STANDARD` flag from the workflow configuration, as it is no longer needed. (`.github/workflows/code-checks.yml`, [.github/workflows/code-checks.ymlL60](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L60))