### PR TITLE
Update Go EditorConfig Configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,7 @@ trim_trailing_whitespace = true
 
 [*.md]
 indent_size = unset
+
+[*.go]
+indent_size = 2
+indent_style = tab


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.editorconfig` file to add formatting rules for Go files.

* [`.editorconfig`](diffhunk://#diff-0947e2727d6bad8cd0ac4122f5314bb5b04e337393075bc4b5ef143b17fcbd5bR13-R16): Added a new section for `*.go` files, specifying an `indent_size` of 2 and `indent_style` set to `tab`.