### PR TITLE
Update Reusable Workflows

### DIFF
--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -12,6 +12,6 @@ jobs:
     name: Clean Caches
     permissions:
       contents: read
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@671deb8527d0e3b1da46cbc87071f5581896e297 # v2025.08.01.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@3247419e78d8921f39ce9bb46d47787a3b5f537b # v2025.08.04.01
     secrets:
       workflow_github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -64,7 +64,7 @@ jobs:
       actions: read
       pull-requests: write
       security-events: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@671deb8527d0e3b1da46cbc87071f5581896e297 # v2025.08.01.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@3247419e78d8921f39ce9bb46d47787a3b5f537b # v2025.08.04.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -76,6 +76,6 @@ jobs:
     strategy:
       matrix:
         language: [actions]
-    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@671deb8527d0e3b1da46cbc87071f5581896e297 # v2025.08.01.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@3247419e78d8921f39ce9bb46d47787a3b5f537b # v2025.08.04.01
     with:
       language: ${{ matrix.language }}

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -12,6 +12,6 @@ jobs:
     name: Common Pull Request Tasks
     permissions:
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@671deb8527d0e3b1da46cbc87071f5581896e297 # v2025.08.01.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@3247419e78d8921f39ce9bb46d47787a3b5f537b # v2025.08.04.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -16,6 +16,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@671deb8527d0e3b1da46cbc87071f5581896e297 # v2025.08.01.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@3247419e78d8921f39ce9bb46d47787a3b5f537b # v2025.08.04.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several GitHub Actions workflow files to use newer versions of shared reusable workflows. The main goal is to ensure all workflows reference the latest versions, which may include important bug fixes or improvements.

**Workflow version updates:**

* Updated the cache cleaning workflow to use `common-clean-caches.yml` version `v2025.08.04.01` (`.github/workflows/clean-caches.yml`).
* Updated the code checks workflow to use `common-code-checks.yml` version `v2025.08.04.01` (`.github/workflows/code-checks.yml`).
* Updated the CodeQL analysis workflow to use `codeql-analysis.yml` version `v2025.08.04.01` (`.github/workflows/code-checks.yml`).
* Updated the pull request tasks workflow to use `common-pull-request-tasks.yml` version `v2025.08.04.01` (`.github/workflows/pull-request-tasks.yml`).
* Updated the label sync workflow to use `common-sync-labels.yml` version `v2025.08.04.01` (`.github/workflows/sync-labels.yml`).