### PR TITLE
Update License to Licence

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -25,7 +25,7 @@ markdown:
               [
                 "docs/*.md",
                 "*.md",
-                "LICENSE",
+                "LICENCE",
                 ".github/pull_request_template.md",
               ]
 python:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the documentation file pattern in the `.github/other-configurations/labeller.yml` configuration. The main change is correcting the spelling of the license file to match the project's naming convention.

Documentation and configuration update:

* Changed the file pattern from `"LICENSE"` to `"LICENCE"` in the `markdown:` section to ensure accurate file labeling.