### PR TITLE
Update Lefthook Minimum Version

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,5 +1,5 @@
 # https://github.com/evilmartians/lefthook
-min_version: 1.13.6
+min_version: 2.0.2
 colors: true
 
 output:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the minimum required version of Lefthook in the `lefthook.yml` configuration file. This ensures compatibility with newer features and fixes in Lefthook.

* Updated the `min_version` of Lefthook from `1.13.6` to `2.0.2` in `lefthook.yml` to require the latest version.