### PR TITLE
Add Dependabot Cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,5 @@ updates:
         update-types:
           - "patch"
           - "minor"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a configuration update to the Dependabot settings, specifically adding a cooldown period for updates.

Dependabot configuration update:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R21-R22): Added a `cooldown` setting with `default-days: 7` to limit how frequently updates are created.